### PR TITLE
Fix preference saving and wire up hidden settings

### DIFF
--- a/TransmissionPlus/AppDelegate.h
+++ b/TransmissionPlus/AppDelegate.h
@@ -53,5 +53,61 @@ typedef NS_ENUM(NSUInteger, AddType) { //
 - (void)postMessage:(NSString*)msg;
 - (void)postFinishMessage:(NSString*)msg;
 
+// Encryption
+- (void)setEncryptionMode:(tr_encryption_mode)mode;
+- (tr_encryption_mode)encryptionMode;
+
+// Seeding limits
+- (void)setRatioLimitEnabled:(BOOL)enabled;
+- (BOOL)ratioLimitEnabled;
+- (void)setRatioLimit:(CGFloat)limit;
+- (CGFloat)ratioLimit;
+- (void)setIdleLimitEnabled:(BOOL)enabled;
+- (BOOL)idleLimitEnabled;
+- (void)setIdleLimitMinutes:(NSInteger)minutes;
+- (NSInteger)idleLimitMinutes;
+
+// Queue
+- (void)setDownloadQueueEnabled:(BOOL)enabled;
+- (BOOL)downloadQueueEnabled;
+- (void)setDownloadQueueSize:(NSInteger)size;
+- (NSInteger)downloadQueueSize;
+- (void)setSeedQueueEnabled:(BOOL)enabled;
+- (BOOL)seedQueueEnabled;
+- (void)setSeedQueueSize:(NSInteger)size;
+- (NSInteger)seedQueueSize;
+
+// Peer discovery
+- (void)setDHTEnabled:(BOOL)enabled;
+- (BOOL)dhtEnabled;
+- (void)setPEXEnabled:(BOOL)enabled;
+- (BOOL)pexEnabled;
+- (void)setUTPEnabled:(BOOL)enabled;
+- (BOOL)utpEnabled;
+- (void)setLPDEnabled:(BOOL)enabled;
+- (BOOL)lpdEnabled;
+
+// Blocklist
+- (void)setBlocklistEnabled:(BOOL)enabled;
+- (BOOL)blocklistEnabled;
+- (void)setBlocklistURL:(NSString *)url;
+- (NSString *)blocklistURL;
+
+// Remote access (RPC)
+- (void)setRPCEnabled:(BOOL)enabled;
+- (BOOL)rpcEnabled;
+- (void)setRPCPort:(NSInteger)port;
+- (NSInteger)rpcPort;
+- (void)setRPCAuthEnabled:(BOOL)enabled;
+- (BOOL)rpcAuthEnabled;
+- (void)setRPCUsername:(NSString *)username;
+- (NSString *)rpcUsername;
+- (void)setRPCPassword:(NSString *)password;
+- (NSString *)rpcPassword;
+
+// Wifi-only
+- (void)setWifiOnlyEnabled:(BOOL)enabled;
+- (BOOL)wifiOnlyEnabled;
+
 @end
 

--- a/TransmissionPlus/Controllers/PrefViewController.mm
+++ b/TransmissionPlus/Controllers/PrefViewController.mm
@@ -14,58 +14,172 @@
 
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
+static NSInteger const PrefSectionPort          = 0;
+static NSInteger const PrefSectionNetwork       = 1;
+static NSInteger const PrefSectionConnections   = 2;
+static NSInteger const PrefSectionUpload        = 3;
+static NSInteger const PrefSectionDownload      = 4;
+static NSInteger const PrefSectionEncryption    = 5;
+static NSInteger const PrefSectionSeeding       = 6;
+static NSInteger const PrefSectionQueue         = 7;
+static NSInteger const PrefSectionPeerDiscovery = 8;
+static NSInteger const PrefSectionBlocklist     = 9;
+static NSInteger const PrefSectionRPC           = 10;
+static NSInteger const PrefSectionMore          = 11;
+static NSInteger const PrefSectionCount         = 12;
+
 @interface PrefViewController() <PortCheckerDelegate, MFMailComposeViewControllerDelegate>
 
 @end
 
 @implementation PrefViewController {
     UITableView *fTableView;
-    
+
     IBOutlet UITableViewCell *fAutoPortMapCell;
     IBOutlet UITableViewCell *fBindPortCell;
     IBOutlet UITableViewCell *fBackgroundDownloadingCell;
     IBOutlet UIButton *fCheckPortButton;
-    
+
     IBOutlet UISwitch *fAutoPortMapSwitch;
     IBOutlet UISwitch *fEnableBackgroundDownloadingSwitch;
     IBOutlet UITextField *fBindPortTextField;
     IBOutlet UIActivityIndicatorView *fPortCheckActivityIndicator;
-    
+
     IBOutlet UILabel *fMaximumConnectionsLabel;
     IBOutlet UITableViewCell *fMaximumConnectionsLabelCell;
     IBOutlet UITextField *fMaximumConnectionsTextField;
-    
+
     IBOutlet UITableViewCell *fConnectionsPerTorrentLabelCell;
     IBOutlet UILabel *fConnectionsPerTorrentLabel;
     IBOutlet UITextField *fConnectionsPerTorrentTextField;
-    
+
     IBOutlet UITableViewCell *fDownloadSpeedLimitCell;
     IBOutlet UITextField *fDownloadSpeedLimitField;
-    
+
     IBOutlet UITableViewCell *fUploadSpeedLimitCell;
     IBOutlet UITextField *fUploadSpeedLimitField;
-    
+
     IBOutlet UITableViewCell *fUploadSpeedLimitEnabledCell;
     IBOutlet UISwitch *fUploadSpeedLimitEnabledSwitch;
-    
+
     IBOutlet UITableViewCell *fDownloadSpeedLimitEnabledCell;
     IBOutlet UISwitch *fDownloadSpeedLimitEnabledSwitch;
-    
+
     IBOutlet UITableViewCell *fContactUsCell;
-        
+
     UIColor *fTextFieldTextColor;
-    
+
     BOOL keyboardIsShowing;
     CGRect keyboardBounds;
-    
+
     NSDictionary *fOriginalPreferences;
     PortChecker *fPortChecker;
+
+    // Network
+    UITableViewCell *fWifiOnlyCell;
+    UISwitch *fWifiOnlySwitch;
+
+    // Encryption
+    UITableViewCell *fEncryptionCell;
+    UISegmentedControl *fEncryptionSegment;
+
+    // Seeding
+    UITableViewCell *fRatioLimitEnabledCell;
+    UISwitch *fRatioLimitEnabledSwitch;
+    UITableViewCell *fRatioLimitCell;
+    UITextField *fRatioLimitField;
+    UITableViewCell *fIdleLimitEnabledCell;
+    UISwitch *fIdleLimitEnabledSwitch;
+    UITableViewCell *fIdleLimitCell;
+    UITextField *fIdleLimitField;
+
+    // Queue
+    UITableViewCell *fDownloadQueueEnabledCell;
+    UISwitch *fDownloadQueueEnabledSwitch;
+    UITableViewCell *fDownloadQueueSizeCell;
+    UITextField *fDownloadQueueSizeField;
+    UITableViewCell *fSeedQueueEnabledCell;
+    UISwitch *fSeedQueueEnabledSwitch;
+    UITableViewCell *fSeedQueueSizeCell;
+    UITextField *fSeedQueueSizeField;
+
+    // Peer discovery
+    UITableViewCell *fDHTCell;
+    UISwitch *fDHTSwitch;
+    UITableViewCell *fPEXCell;
+    UISwitch *fPEXSwitch;
+    UITableViewCell *fUTPCell;
+    UISwitch *fUTPSwitch;
+    UITableViewCell *fLPDCell;
+    UISwitch *fLPDSwitch;
+
+    // Blocklist
+    UITableViewCell *fBlocklistEnabledCell;
+    UISwitch *fBlocklistEnabledSwitch;
+    UITableViewCell *fBlocklistURLCell;
+    UITextField *fBlocklistURLField;
+
+    // RPC
+    UITableViewCell *fRPCEnabledCell;
+    UISwitch *fRPCEnabledSwitch;
+    UITableViewCell *fRPCPortCell;
+    UITextField *fRPCPortField;
+    UITableViewCell *fRPCAuthEnabledCell;
+    UISwitch *fRPCAuthEnabledSwitch;
+    UITableViewCell *fRPCUsernameCell;
+    UITextField *fRPCUsernameField;
+    UITableViewCell *fRPCPasswordCell;
+    UITextField *fRPCPasswordField;
 }
 
 @synthesize tableView = fTableView;
 @synthesize originalPreferences = fOriginalPreferences;
 @synthesize portChecker = fPortChecker;
 @synthesize controller = fController;
+
+#pragma mark - Cell factory helpers
+
+- (UITableViewCell *)cellWithLabel:(NSString *)label switchControl:(UISwitch *)sw
+{
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    cell.textLabel.text = label;
+    cell.textLabel.font = [UIFont fontWithName:@"Helvetica-Bold" size:14];
+    cell.accessoryView = sw;
+    return cell;
+}
+
+- (UITableViewCell *)cellWithLabel:(NSString *)label textField:(UITextField *)tf keyboard:(UIKeyboardType)keyboardType toolbar:(UIToolbar *)toolbar
+{
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+
+    UILabel *lbl = [[UILabel alloc] init];
+    lbl.text = label;
+    lbl.font = [UIFont fontWithName:@"Helvetica-Bold" size:14];
+    lbl.translatesAutoresizingMaskIntoConstraints = NO;
+    [cell.contentView addSubview:lbl];
+
+    tf.textAlignment = NSTextAlignmentRight;
+    tf.font = [UIFont fontWithName:@"Helvetica" size:18];
+    tf.textColor = self.view.tintColor;
+    tf.keyboardType = keyboardType;
+    tf.delegate = self;
+    tf.inputAccessoryView = toolbar;
+    tf.translatesAutoresizingMaskIntoConstraints = NO;
+    [cell.contentView addSubview:tf];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [lbl.leadingAnchor constraintEqualToAnchor:cell.contentView.leadingAnchor constant:16],
+        [lbl.centerYAnchor constraintEqualToAnchor:cell.contentView.centerYAnchor],
+        [tf.trailingAnchor constraintEqualToAnchor:cell.contentView.trailingAnchor constant:-16],
+        [tf.centerYAnchor constraintEqualToAnchor:cell.contentView.centerYAnchor],
+        [tf.leadingAnchor constraintGreaterThanOrEqualToAnchor:lbl.trailingAnchor constant:8],
+        [tf.widthAnchor constraintGreaterThanOrEqualToConstant:60],
+    ]];
+
+    return cell;
+}
 
 
 - (void) textFieldDidBeginEditing:(UITextField *)textField {
@@ -74,7 +188,7 @@
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField
 {
-    
+
     return YES;
 }
 
@@ -110,8 +224,8 @@
         if (indexPath)
             [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle animated:YES];
     }
-    
-    if (textField == fBindPortTextField) {
+
+    if (textField == fBindPortTextField || textField == fRPCPortField) {
         NSString *newStr = [textField.text stringByReplacingCharactersInRange:range withString:string];
         if ([newStr length] == 0) return YES;
         NSScanner *scanner = [NSScanner scannerWithString:newStr];
@@ -126,20 +240,28 @@
     return YES;
 }
 
+#pragma mark - Table view data source
+
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
-    return 6;
+    return PrefSectionCount;
 }
 
 - (NSInteger)tableView:(UITableView *)table numberOfRowsInSection:(NSInteger)section
 {
     switch (section) {
-        case 0: return 2;
-        case 1: return 1;
-        case 2: return 2;
-        case 3: return 2;
-        case 4: return 2;
-        case 5: return 1;
+        case PrefSectionPort:          return 2;
+        case PrefSectionNetwork:       return 2;
+        case PrefSectionConnections:   return 2;
+        case PrefSectionUpload:        return 2;
+        case PrefSectionDownload:      return 2;
+        case PrefSectionEncryption:    return 1;
+        case PrefSectionSeeding:       return 4;
+        case PrefSectionQueue:         return 4;
+        case PrefSectionPeerDiscovery: return 4;
+        case PrefSectionBlocklist:     return 2;
+        case PrefSectionRPC:           return 5;
+        case PrefSectionMore:          return 1;
     }
     return 0;
 }
@@ -147,12 +269,18 @@
 - (NSString*)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     switch (section) {
-        case 0: return @"Port Listening";
-        case 1: return @"Background Downloading";
-        case 2: return @"Connections";
-        case 3: return @"Upload";
-        case 4: return @"Download";
-        case 5: return @"More";
+        case PrefSectionPort:          return @"Port Listening";
+        case PrefSectionNetwork:       return @"Network";
+        case PrefSectionConnections:   return @"Connections";
+        case PrefSectionUpload:        return @"Upload";
+        case PrefSectionDownload:      return @"Download";
+        case PrefSectionEncryption:    return @"Encryption";
+        case PrefSectionSeeding:       return @"Seeding";
+        case PrefSectionQueue:         return @"Queue";
+        case PrefSectionPeerDiscovery: return @"Peer Discovery";
+        case PrefSectionBlocklist:     return @"Blocklist";
+        case PrefSectionRPC:           return @"Remote Access";
+        case PrefSectionMore:          return @"More";
     }
     return nil;
 }
@@ -160,10 +288,11 @@
 - (NSString*)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     switch (section) {
-        case 0: return nil;
-        case 1: return @"Enable downloading while in background through multimedia functions";
-        case 2: return @"Caution! Too many connections will make your device unstable.";
-        case 3: return @"30KB/s is recommended for upload.";
+        case PrefSectionNetwork:       return @"Enable downloading while in background through multimedia functions.";
+        case PrefSectionConnections:   return @"Caution! Too many connections will make your device unstable.";
+        case PrefSectionUpload:        return @"30KB/s is recommended for upload.";
+        case PrefSectionEncryption:    return @"Encryption protects your traffic from eavesdropping.";
+        case PrefSectionRPC:           return @"Allows controlling iTransmission from a web browser or remote client.";
     }
     return nil;
 }
@@ -171,41 +300,88 @@
 - (UITableViewCell*)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     switch (indexPath.section) {
-        case 0: {
+        case PrefSectionPort: {
             switch (indexPath.row) {
                 case 0: return fBindPortCell;
                 case 1: return fAutoPortMapCell;
             }
+            break;
         }
-        case 1:
-        {
+        case PrefSectionNetwork: {
             switch (indexPath.row) {
                 case 0: return fBackgroundDownloadingCell;
+                case 1: return fWifiOnlyCell;
             }
+            break;
         }
-        case 2:
-        {
+        case PrefSectionConnections: {
             switch (indexPath.row) {
                 case 0: return fMaximumConnectionsLabelCell;
                 case 1: return fConnectionsPerTorrentLabelCell;
             }
+            break;
         }
-        case 3:
-        {
+        case PrefSectionUpload: {
             switch (indexPath.row) {
                 case 0: return fUploadSpeedLimitEnabledCell;
                 case 1: return fUploadSpeedLimitCell;
-                
             }
+            break;
         }
-        case 4:
-        {
+        case PrefSectionDownload: {
             switch (indexPath.row) {
                 case 0: return fDownloadSpeedLimitEnabledCell;
                 case 1: return fDownloadSpeedLimitCell;
             }
+            break;
         }
-        case 5:
+        case PrefSectionEncryption:
+            return fEncryptionCell;
+        case PrefSectionSeeding: {
+            switch (indexPath.row) {
+                case 0: return fRatioLimitEnabledCell;
+                case 1: return fRatioLimitCell;
+                case 2: return fIdleLimitEnabledCell;
+                case 3: return fIdleLimitCell;
+            }
+            break;
+        }
+        case PrefSectionQueue: {
+            switch (indexPath.row) {
+                case 0: return fDownloadQueueEnabledCell;
+                case 1: return fDownloadQueueSizeCell;
+                case 2: return fSeedQueueEnabledCell;
+                case 3: return fSeedQueueSizeCell;
+            }
+            break;
+        }
+        case PrefSectionPeerDiscovery: {
+            switch (indexPath.row) {
+                case 0: return fDHTCell;
+                case 1: return fPEXCell;
+                case 2: return fUTPCell;
+                case 3: return fLPDCell;
+            }
+            break;
+        }
+        case PrefSectionBlocklist: {
+            switch (indexPath.row) {
+                case 0: return fBlocklistEnabledCell;
+                case 1: return fBlocklistURLCell;
+            }
+            break;
+        }
+        case PrefSectionRPC: {
+            switch (indexPath.row) {
+                case 0: return fRPCEnabledCell;
+                case 1: return fRPCPortCell;
+                case 2: return fRPCAuthEnabledCell;
+                case 3: return fRPCUsernameCell;
+                case 4: return fRPCPasswordCell;
+            }
+            break;
+        }
+        case PrefSectionMore:
             return fContactUsCell;
     }
     return [UITableViewCell new];
@@ -214,12 +390,12 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
 
-    if (indexPath.section == 5 && [MFMailComposeViewController canSendMail]) {
+    if (indexPath.section == PrefSectionMore && [MFMailComposeViewController canSendMail]) {
         MFMailComposeViewController* mailComposer = [[MFMailComposeViewController alloc] init];
         mailComposer.mailComposeDelegate = self;
         [mailComposer setSubject:@"iTransmission feedback"];
         [mailComposer setToRecipients:@[@"itransmissionapp@gmail.com"]];
-        
+
         if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
             mailComposer.modalPresentationStyle = UIModalPresentationCurrentContext;
         }
@@ -247,13 +423,15 @@
 	if ([c status] == PortStatusClosed) {
 		msg = [NSString stringWithFormat:@"Oh bad. Your port %li is not accessable from outside.", (long)[c portToCheck]];
 	}
-	
+
 	[fPortCheckActivityIndicator stopAnimating];
-    
+
     UIAlertController *alertVC = [UIAlertController alertControllerWithTitle:@"Port check" message:msg preferredStyle:UIAlertControllerStyleAlert];
     [alertVC addAction:[UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleDefault handler:nil]];
     [self presentViewController:alertVC animated:YES completion:nil];
 }
+
+#pragma mark - Save / load
 
 - (void)savePreferences {
     tr_session *fHandle = [self.controller sessionHandle];
@@ -288,6 +466,28 @@
     connections = [[fConnectionsPerTorrentTextField text] integerValue];
     [self.controller setConnectionsPerTorrent:connections];
 
+    // set seeding limits
+    [self.controller setRatioLimit:[[fRatioLimitField text] floatValue]];
+    [self.controller setIdleLimitMinutes:[[fIdleLimitField text] integerValue]];
+
+    // set queue sizes
+    [self.controller setDownloadQueueSize:[[fDownloadQueueSizeField text] integerValue]];
+    [self.controller setSeedQueueSize:[[fSeedQueueSizeField text] integerValue]];
+
+    // set blocklist URL
+    NSString *blocklistURL = [fBlocklistURLField text];
+    if (blocklistURL.length > 0)
+        [self.controller setBlocklistURL:blocklistURL];
+
+    // set RPC text fields
+    [self.controller setRPCPort:[[fRPCPortField text] integerValue]];
+    NSString *rpcUser = [fRPCUsernameField text];
+    if (rpcUser)
+        [self.controller setRPCUsername:rpcUser];
+    NSString *rpcPass = [fRPCPasswordField text];
+    if (rpcPass)
+        [self.controller setRPCPassword:rpcPass];
+
     [fDefaults synchronize];
 
     [self performSelector:@selector(loadPreferences) withObject:nil afterDelay:0.0f];
@@ -295,18 +495,18 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
 	[fCheckPortButton addTarget:self action:@selector(portCheckButtonClicked) forControlEvents:UIControlEventTouchUpInside];
-	
+
     self.controller = (AppDelegate*)[[UIApplication sharedApplication] delegate];
-    
+
     [fConnectionsPerTorrentTextField setText:[NSString stringWithFormat:@"%ld", (long)[self.controller connectionsPerTorrent]]];
     [fMaximumConnectionsTextField setText:[NSString stringWithFormat:@"%ld", (long)[self.controller globalMaximumConnections]]];
     [fUploadSpeedLimitField setText:[NSString stringWithFormat:@"%ld", (long)[self.controller globalUploadSpeedLimit]]];
     [fDownloadSpeedLimitField setText:[NSString stringWithFormat:@"%ld", (long)[self.controller globalDownloadSpeedLimit]]];
     [fUploadSpeedLimitEnabledSwitch setOn:[self.controller globalUploadSpeedLimitEnabled]];
     [fDownloadSpeedLimitEnabledSwitch setOn:[self.controller globalDownloadSpeedLimitEnabled]];
-    
+
     UIToolbar *keyboardDoneButtonView = [[UIToolbar alloc] init];
     [keyboardDoneButtonView sizeToFit];
     UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:@"Done"
@@ -314,7 +514,7 @@
                                                                   action:@selector(keyboardDoneClicked)];
     [keyboardDoneButtonView setItems:[NSArray arrayWithObjects:doneButton, nil]];
     [keyboardDoneButtonView sizeToFit];
-    
+
     fBindPortTextField.delegate = self;
     fUploadSpeedLimitField.delegate = self;
     fDownloadSpeedLimitField.delegate = self;
@@ -325,14 +525,135 @@
     fDownloadSpeedLimitField.inputAccessoryView = keyboardDoneButtonView;
     fConnectionsPerTorrentTextField.inputAccessoryView = keyboardDoneButtonView;
     fMaximumConnectionsTextField.inputAccessoryView = keyboardDoneButtonView;
-    
+
     fContactUsCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
     fContactUsCell.textLabel.text = @"Contact Us";
     fContactUsCell.textLabel.textAlignment = NSTextAlignmentCenter;
     fContactUsCell.textLabel.font = [UIFont boldSystemFontOfSize:16];
-    
+
+    // Wifi-only
+    fWifiOnlySwitch = [[UISwitch alloc] init];
+    fWifiOnlyCell = [self cellWithLabel:@"Wifi Only" switchControl:fWifiOnlySwitch];
+    [fWifiOnlySwitch setOn:[self.controller wifiOnlyEnabled]];
+    [fWifiOnlySwitch addTarget:self action:@selector(wifiOnlySwitchChanged:) forControlEvents:UIControlEventValueChanged];
+
+    // Encryption
+    fEncryptionCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    fEncryptionCell.selectionStyle = UITableViewCellSelectionStyleNone;
+    fEncryptionSegment = [[UISegmentedControl alloc] initWithItems:@[@"Off", @"Preferred", @"Required"]];
+    fEncryptionSegment.translatesAutoresizingMaskIntoConstraints = NO;
+    [fEncryptionSegment setSelectedSegmentIndex:[self.controller encryptionMode]];
+    [fEncryptionSegment addTarget:self action:@selector(encryptionModeChanged:) forControlEvents:UIControlEventValueChanged];
+    [fEncryptionCell.contentView addSubview:fEncryptionSegment];
+    [NSLayoutConstraint activateConstraints:@[
+        [fEncryptionSegment.leadingAnchor constraintEqualToAnchor:fEncryptionCell.contentView.leadingAnchor constant:16],
+        [fEncryptionSegment.trailingAnchor constraintEqualToAnchor:fEncryptionCell.contentView.trailingAnchor constant:-16],
+        [fEncryptionSegment.centerYAnchor constraintEqualToAnchor:fEncryptionCell.contentView.centerYAnchor],
+    ]];
+
+    // Seeding — ratio
+    fRatioLimitEnabledSwitch = [[UISwitch alloc] init];
+    fRatioLimitEnabledCell = [self cellWithLabel:@"Stop at Ratio" switchControl:fRatioLimitEnabledSwitch];
+    [fRatioLimitEnabledSwitch setOn:[self.controller ratioLimitEnabled]];
+    [fRatioLimitEnabledSwitch addTarget:self action:@selector(ratioLimitEnabledChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fRatioLimitField = [[UITextField alloc] init];
+    fRatioLimitCell = [self cellWithLabel:@"Ratio Limit" textField:fRatioLimitField keyboard:UIKeyboardTypeDecimalPad toolbar:keyboardDoneButtonView];
+    [fRatioLimitField setText:[NSString stringWithFormat:@"%.2f", [self.controller ratioLimit]]];
+
+    // Seeding — idle
+    fIdleLimitEnabledSwitch = [[UISwitch alloc] init];
+    fIdleLimitEnabledCell = [self cellWithLabel:@"Stop if Idle" switchControl:fIdleLimitEnabledSwitch];
+    [fIdleLimitEnabledSwitch setOn:[self.controller idleLimitEnabled]];
+    [fIdleLimitEnabledSwitch addTarget:self action:@selector(idleLimitEnabledChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fIdleLimitField = [[UITextField alloc] init];
+    fIdleLimitCell = [self cellWithLabel:@"Idle Minutes" textField:fIdleLimitField keyboard:UIKeyboardTypeNumberPad toolbar:keyboardDoneButtonView];
+    [fIdleLimitField setText:[NSString stringWithFormat:@"%ld", (long)[self.controller idleLimitMinutes]]];
+
+    // Queue — download
+    fDownloadQueueEnabledSwitch = [[UISwitch alloc] init];
+    fDownloadQueueEnabledCell = [self cellWithLabel:@"Download Queue" switchControl:fDownloadQueueEnabledSwitch];
+    [fDownloadQueueEnabledSwitch setOn:[self.controller downloadQueueEnabled]];
+    [fDownloadQueueEnabledSwitch addTarget:self action:@selector(downloadQueueEnabledChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fDownloadQueueSizeField = [[UITextField alloc] init];
+    fDownloadQueueSizeCell = [self cellWithLabel:@"Max Downloads" textField:fDownloadQueueSizeField keyboard:UIKeyboardTypeNumberPad toolbar:keyboardDoneButtonView];
+    [fDownloadQueueSizeField setText:[NSString stringWithFormat:@"%ld", (long)[self.controller downloadQueueSize]]];
+
+    // Queue — seed
+    fSeedQueueEnabledSwitch = [[UISwitch alloc] init];
+    fSeedQueueEnabledCell = [self cellWithLabel:@"Seed Queue" switchControl:fSeedQueueEnabledSwitch];
+    [fSeedQueueEnabledSwitch setOn:[self.controller seedQueueEnabled]];
+    [fSeedQueueEnabledSwitch addTarget:self action:@selector(seedQueueEnabledChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fSeedQueueSizeField = [[UITextField alloc] init];
+    fSeedQueueSizeCell = [self cellWithLabel:@"Max Seeds" textField:fSeedQueueSizeField keyboard:UIKeyboardTypeNumberPad toolbar:keyboardDoneButtonView];
+    [fSeedQueueSizeField setText:[NSString stringWithFormat:@"%ld", (long)[self.controller seedQueueSize]]];
+
+    // Peer discovery
+    fDHTSwitch = [[UISwitch alloc] init];
+    fDHTCell = [self cellWithLabel:@"DHT" switchControl:fDHTSwitch];
+    [fDHTSwitch setOn:[self.controller dhtEnabled]];
+    [fDHTSwitch addTarget:self action:@selector(dhtSwitchChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fPEXSwitch = [[UISwitch alloc] init];
+    fPEXCell = [self cellWithLabel:@"PEX" switchControl:fPEXSwitch];
+    [fPEXSwitch setOn:[self.controller pexEnabled]];
+    [fPEXSwitch addTarget:self action:@selector(pexSwitchChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fUTPSwitch = [[UISwitch alloc] init];
+    fUTPCell = [self cellWithLabel:@"uTP" switchControl:fUTPSwitch];
+    [fUTPSwitch setOn:[self.controller utpEnabled]];
+    [fUTPSwitch addTarget:self action:@selector(utpSwitchChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fLPDSwitch = [[UISwitch alloc] init];
+    fLPDCell = [self cellWithLabel:@"Local Peer Discovery" switchControl:fLPDSwitch];
+    [fLPDSwitch setOn:[self.controller lpdEnabled]];
+    [fLPDSwitch addTarget:self action:@selector(lpdSwitchChanged:) forControlEvents:UIControlEventValueChanged];
+
+    // Blocklist
+    fBlocklistEnabledSwitch = [[UISwitch alloc] init];
+    fBlocklistEnabledCell = [self cellWithLabel:@"Enable Blocklist" switchControl:fBlocklistEnabledSwitch];
+    [fBlocklistEnabledSwitch setOn:[self.controller blocklistEnabled]];
+    [fBlocklistEnabledSwitch addTarget:self action:@selector(blocklistEnabledChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fBlocklistURLField = [[UITextField alloc] init];
+    fBlocklistURLCell = [self cellWithLabel:@"URL" textField:fBlocklistURLField keyboard:UIKeyboardTypeURL toolbar:keyboardDoneButtonView];
+    fBlocklistURLField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    fBlocklistURLField.autocorrectionType = UITextAutocorrectionTypeNo;
+    [fBlocklistURLField setText:[self.controller blocklistURL]];
+
+    // RPC
+    fRPCEnabledSwitch = [[UISwitch alloc] init];
+    fRPCEnabledCell = [self cellWithLabel:@"Enable Remote Access" switchControl:fRPCEnabledSwitch];
+    [fRPCEnabledSwitch setOn:[self.controller rpcEnabled]];
+    [fRPCEnabledSwitch addTarget:self action:@selector(rpcEnabledChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fRPCPortField = [[UITextField alloc] init];
+    fRPCPortCell = [self cellWithLabel:@"Port" textField:fRPCPortField keyboard:UIKeyboardTypeNumberPad toolbar:keyboardDoneButtonView];
+    [fRPCPortField setText:[NSString stringWithFormat:@"%ld", (long)[self.controller rpcPort]]];
+
+    fRPCAuthEnabledSwitch = [[UISwitch alloc] init];
+    fRPCAuthEnabledCell = [self cellWithLabel:@"Require Authentication" switchControl:fRPCAuthEnabledSwitch];
+    [fRPCAuthEnabledSwitch setOn:[self.controller rpcAuthEnabled]];
+    [fRPCAuthEnabledSwitch addTarget:self action:@selector(rpcAuthEnabledChanged:) forControlEvents:UIControlEventValueChanged];
+
+    fRPCUsernameField = [[UITextField alloc] init];
+    fRPCUsernameCell = [self cellWithLabel:@"Username" textField:fRPCUsernameField keyboard:UIKeyboardTypeDefault toolbar:keyboardDoneButtonView];
+    fRPCUsernameField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    fRPCUsernameField.autocorrectionType = UITextAutocorrectionTypeNo;
+    [fRPCUsernameField setText:[self.controller rpcUsername]];
+
+    fRPCPasswordField = [[UITextField alloc] init];
+    fRPCPasswordCell = [self cellWithLabel:@"Password" textField:fRPCPasswordField keyboard:UIKeyboardTypeDefault toolbar:keyboardDoneButtonView];
+    fRPCPasswordField.secureTextEntry = YES;
+    fRPCPasswordField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    fRPCPasswordField.autocorrectionType = UITextAutocorrectionTypeNo;
+    [fRPCPasswordField setText:[self.controller rpcPassword]];
+
     [self.navigationController setToolbarHidden:YES animated:NO];
-    
+
     [self loadPreferences];
 
 }
@@ -353,18 +674,20 @@
 	[_originalPref setInteger:[fDefaults integerForKey:@"BindPort"] forKey:@"BindPort"];
     [_originalPref setBool:[fDefaults boolForKey:@"BackgroundDownloading"] forKey:@"BackgroundDownloading"];
 	self.originalPreferences = [NSDictionary dictionaryWithDictionary:_originalPref];
-	
+
 	[fAutoPortMapSwitch setOn:[self.originalPreferences boolForKey:@"NatTraversal"]];
 	[fBindPortTextField setText:[NSString stringWithFormat:@"%li", (long)[self.originalPreferences integerForKey:@"BindPort"]]];
     [fEnableBackgroundDownloadingSwitch setOn:[self.originalPreferences boolForKey:@"BackgroundDownloading"]];
-    
+
     [self.navigationItem.rightBarButtonItem setEnabled:NO];
 }
+
+#pragma mark - Switch actions (save immediately)
 
 - (IBAction)enableBackgroundDownloadSwitchChanged:(id)sender
 {
     [self.navigationItem.rightBarButtonItem setEnabled:YES];
-    
+
     NSNumber *value = [NSNumber numberWithBool:fEnableBackgroundDownloadingSwitch.on];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"AudioPrefChanged" object:value];
 }
@@ -393,6 +716,73 @@
     [self.controller setGlobalMaximumConnections:intValue];
 }
 
+- (void)wifiOnlySwitchChanged:(id)sender
+{
+    [self.controller setWifiOnlyEnabled:[fWifiOnlySwitch isOn]];
+}
+
+- (void)encryptionModeChanged:(id)sender
+{
+    [self.controller setEncryptionMode:(tr_encryption_mode)[fEncryptionSegment selectedSegmentIndex]];
+}
+
+- (void)ratioLimitEnabledChanged:(id)sender
+{
+    [self.controller setRatioLimitEnabled:[fRatioLimitEnabledSwitch isOn]];
+}
+
+- (void)idleLimitEnabledChanged:(id)sender
+{
+    [self.controller setIdleLimitEnabled:[fIdleLimitEnabledSwitch isOn]];
+}
+
+- (void)downloadQueueEnabledChanged:(id)sender
+{
+    [self.controller setDownloadQueueEnabled:[fDownloadQueueEnabledSwitch isOn]];
+}
+
+- (void)seedQueueEnabledChanged:(id)sender
+{
+    [self.controller setSeedQueueEnabled:[fSeedQueueEnabledSwitch isOn]];
+}
+
+- (void)dhtSwitchChanged:(id)sender
+{
+    [self.controller setDHTEnabled:[fDHTSwitch isOn]];
+}
+
+- (void)pexSwitchChanged:(id)sender
+{
+    [self.controller setPEXEnabled:[fPEXSwitch isOn]];
+}
+
+- (void)utpSwitchChanged:(id)sender
+{
+    [self.controller setUTPEnabled:[fUTPSwitch isOn]];
+}
+
+- (void)lpdSwitchChanged:(id)sender
+{
+    [self.controller setLPDEnabled:[fLPDSwitch isOn]];
+}
+
+- (void)blocklistEnabledChanged:(id)sender
+{
+    [self.controller setBlocklistEnabled:[fBlocklistEnabledSwitch isOn]];
+}
+
+- (void)rpcEnabledChanged:(id)sender
+{
+    [self.controller setRPCEnabled:[fRPCEnabledSwitch isOn]];
+}
+
+- (void)rpcAuthEnabledChanged:(id)sender
+{
+    [self.controller setRPCAuthEnabled:[fRPCAuthEnabledSwitch isOn]];
+}
+
+#pragma mark - Done / dismiss
+
 - (IBAction)doneClicked:(id)sender {
     [self savePreferences];
     [self dismissViewControllerAnimated:YES completion:nil];
@@ -404,13 +794,23 @@
     [fDownloadSpeedLimitField resignFirstResponder];
     [fMaximumConnectionsTextField resignFirstResponder];
     [fConnectionsPerTorrentTextField resignFirstResponder];
-    
+    [fRatioLimitField resignFirstResponder];
+    [fIdleLimitField resignFirstResponder];
+    [fDownloadQueueSizeField resignFirstResponder];
+    [fSeedQueueSizeField resignFirstResponder];
+    [fBlocklistURLField resignFirstResponder];
+    [fRPCPortField resignFirstResponder];
+    [fRPCUsernameField resignFirstResponder];
+    [fRPCPasswordField resignFirstResponder];
+
     [self savePreferences];
 }
 
+#pragma mark - Keyboard handling
+
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    
+
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHide:)
        name:UIKeyboardWillHideNotification object:nil];
@@ -428,7 +828,7 @@
     NSDictionary *userInfo = [notification userInfo];
     NSValue *keyboardBoundsValue = [userInfo objectForKey:UIKeyboardFrameEndUserInfoKey];
     [keyboardBoundsValue getValue:&keyboardBounds];
-    
+
     [self resizeToFit];
 }
 
@@ -439,11 +839,11 @@
 }
 
 - (void)resizeToFit {
-    
+
     __weak PrefViewController *wself = self;
-    
+
     CGFloat keyboardHeight = keyboardBounds.size.height;
-    
+
     [UIView animateWithDuration:0.3 animations:^{
         wself.bottomConstraint.constant = keyboardHeight;
         [wself.tableView setNeedsLayout];

--- a/TransmissionPlus/Defaults.plist
+++ b/TransmissionPlus/Defaults.plist
@@ -206,5 +206,9 @@
 	<true/>
 	<key>BackgroundDownloading</key>
 	<true/>
+	<key>WiFiOnlyDownloading</key>
+	<false/>
+	<key>RPCPassword</key>
+	<string></string>
 </dict>
 </plist>

--- a/TransmissionPlus/Main_Storyboard.storyboard
+++ b/TransmissionPlus/Main_Storyboard.storyboard
@@ -1376,7 +1376,7 @@
                                 <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="18"/>
                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                 <connections>
-                                    <action selector="maximumConnectionsPerTorrentChanged:" destination="yi8-CF-b6c" eventType="valueChanged" id="54m-GR-pus"/>
+                                    <action selector="maximumConnectionsPerTorrentChanged:" destination="yi8-CF-b6c" eventType="editingDidEnd" id="54m-GR-pus"/>
                                 </connections>
                             </textField>
                         </subviews>
@@ -1408,7 +1408,7 @@
                                 <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="18"/>
                                 <textInputTraits key="textInputTraits"/>
                                 <connections>
-                                    <action selector="connectionsPerTorrentChanged:" destination="yi8-CF-b6c" eventType="valueChanged" id="0U2-C3-i2p"/>
+                                    <action selector="connectionsPerTorrentChanged:" destination="yi8-CF-b6c" eventType="editingDidEnd" id="0U2-C3-i2p"/>
                                 </connections>
                             </textField>
                         </subviews>


### PR DESCRIPTION
## Summary

- Connection limits (peers total, peers per torrent) and speed limits (upload, download) were not persisting on iOS 14+. Root causes were a wrong method call in `maximumConnectionsPerTorrentChanged:`, missing saves in `savePreferences`, re-entrant `resignFirstResponder`, fragile `superview.superview` traversal, and storyboard wiring using `valueChanged` instead of `editingDidEnd`.
- `EncryptionPrefer`/`EncryptionRequire` keys existed in `Defaults.plist` but `TR_KEY_encryption` was never passed to the engine during session initialisation. Added a three-way segmented control (off / preferred / required).
- Many settings were already wired to the libtransmission engine but had no UI. Added new preference sections for seeding limits (ratio + idle), queue limits (download + seed), peer discovery (DHT, PEX, uTP, LPD), blocklist (enable + URL), and remote access/RPC (enable, port, authentication, username, password).
- Added a wifi-only mode using `NWPathMonitor` to pause active torrents when wifi is unavailable and resume them when it returns.

Partially addresses #7.